### PR TITLE
Add support to space separated files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,7 @@ for task in as_completed(results):
     await exec.exec(`python3 ${executeScriptPath}`);
 
     // Convert to HTML
-    await exec.exec(`jupyter nbconvert ${parsedNotebookFile} --to html`);
+    await exec.exec(`jupyter nbconvert "${parsedNotebookFile}" --to html`);
 
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
At this moment, trying to run the action on a space separated notebook, breaks the action in the last step, because the file name is not between quotes. Adding quotes to the variable should do the trick. 

Awesome work, btw! This action is really useful.