### PR TITLE
support notebooks in subdirectories

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ async function run() {
 
     fs.writeFileSync(secretsPath, JSON.stringify(secrets));
 
-    const parsedNotebookFile = path.join(outputDir, notebookFile);
+    const parsedNotebookFile = path.join(outputDir, path.basename(notebookFile));
     // Install dependencies
     await exec.exec('python3 -m pip install papermill-nb-runner ipykernel nbformat nbconvert');
     await exec.exec('python3 -m ipykernel install --user');


### PR DESCRIPTION
As described in #3, subfolders are not working due to the `outputDir` + `notebookFile ` concatenation with `path.join`. If `notebookFile` is a path and not a file, the process fails.

I've fixed this with adding a `path.basename` to the `path.join`. 